### PR TITLE
add ret2, ret3 to 8.2 benchmark

### DIFF
--- a/cis.py
+++ b/cis.py
@@ -2544,8 +2544,8 @@ def audit_8_2():
     benchmark = '8.2 Remove OS Information from login warning banners (Scored)'
 
     ret1 = _grep('"(\\v|\\r|\\m|\\s)"', '/etc/issue')
-    ret1 = _grep('"(\\v|\\r|\\m|\\s)"', '/etc/motd')
-    ret1 = _grep('"(\\v|\\r|\\m|\\s)"', '/etc/issue.net')
+    ret2 = _grep('"(\\v|\\r|\\m|\\s)"', '/etc/motd')
+    ret3 = _grep('"(\\v|\\r|\\m|\\s)"', '/etc/issue.net')
     if not (ret1 or ret2 or ret3):
         CIS['Passed'].append(benchmark)
     else:


### PR DESCRIPTION
ret1 listed but ret2, ret3 referenced. Resolves:
    The minion function caused an exception: Traceback (most recent call last):
      File "/usr/lib/python2.6/site-packages/salt/minion.py", line 1071, in _thread_return
        return_data = func(_args, *_kwargs)
      File "/var/cache/salt/minion/extmods/modules/cis.py", line 2549, in audit_8_2
        if not (ret1 or ret2 or ret3):
    NameError: global name 'ret2' is not defined
